### PR TITLE
Include missing files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 graft wickedhot/templates
 global-exclude *.pyc
+include *.md


### PR DESCRIPTION
Include missing files in sdist for #1

Tested with

```
++ mktemp -d
+ D=/tmp/tmp.ZXZfJegj5c
+ trap 'rm -rf /tmp/tmp.ZXZfJegj5c' EXIT
+ python -m venv /tmp/tmp.ZXZfJegj5c
+ python setup.py sdist -d /tmp/tmp.ZXZfJegj5c
running sdist
running egg_info
writing wickedhot.egg-info/PKG-INFO
writing dependency_links to wickedhot.egg-info/dependency_links.txt
writing requirements to wickedhot.egg-info/requires.txt
writing top-level names to wickedhot.egg-info/top_level.txt
reading manifest file 'wickedhot.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
warning: no previously-included files matching '*.pyc' found anywhere in distribution
writing manifest file 'wickedhot.egg-info/SOURCES.txt'
running check
creating wickedhot-0.1.6
creating wickedhot-0.1.6/test
creating wickedhot-0.1.6/wickedhot
creating wickedhot-0.1.6/wickedhot.egg-info
creating wickedhot-0.1.6/wickedhot/templates
copying files to wickedhot-0.1.6...
copying HISTORY.md -> wickedhot-0.1.6
copying MANIFEST.in -> wickedhot-0.1.6
copying README.md -> wickedhot-0.1.6
copying setup.py -> wickedhot-0.1.6
copying test/test_form_generator.py -> wickedhot-0.1.6/test
copying test/test_one_hot_encode.py -> wickedhot-0.1.6/test
copying test/test_one_hot_encoder.py -> wickedhot-0.1.6/test
copying wickedhot/__init__.py -> wickedhot-0.1.6/wickedhot
copying wickedhot/form_generator.py -> wickedhot-0.1.6/wickedhot
copying wickedhot/html_form.py -> wickedhot-0.1.6/wickedhot
copying wickedhot/one_hot_encode.py -> wickedhot-0.1.6/wickedhot
copying wickedhot/one_hot_encoder.py -> wickedhot-0.1.6/wickedhot
copying wickedhot/res_sample.py -> wickedhot-0.1.6/wickedhot
copying wickedhot.egg-info/PKG-INFO -> wickedhot-0.1.6/wickedhot.egg-info
copying wickedhot.egg-info/SOURCES.txt -> wickedhot-0.1.6/wickedhot.egg-info
copying wickedhot.egg-info/dependency_links.txt -> wickedhot-0.1.6/wickedhot.egg-info
copying wickedhot.egg-info/requires.txt -> wickedhot-0.1.6/wickedhot.egg-info
copying wickedhot.egg-info/top_level.txt -> wickedhot-0.1.6/wickedhot.egg-info
copying wickedhot/templates/__init__.py -> wickedhot-0.1.6/wickedhot/templates
copying wickedhot/templates/alpaca_example.json -> wickedhot-0.1.6/wickedhot/templates
copying wickedhot/templates/alpaca_form.html -> wickedhot-0.1.6/wickedhot/templates
copying wickedhot/templates/alpaca_header.html -> wickedhot-0.1.6/wickedhot/templates
copying wickedhot/templates/alpaca_index.html -> wickedhot-0.1.6/wickedhot/templates
Writing wickedhot-0.1.6/setup.cfg
Creating tar archive
removing 'wickedhot-0.1.6' (and everything under it)
+ /tmp/tmp.ZXZfJegj5c/bin/pip install /tmp/tmp.ZXZfJegj5c/wickedhot-0.1.6.tar.gz
Processing /tmp/tmp.ZXZfJegj5c/wickedhot-0.1.6.tar.gz
Collecting pytest (from wickedhot==0.1.6)
  Using cached https://files.pythonhosted.org/packages/6c/f9/9f2b6c672c8f8bb87a4c1bd52c1b57213627b035305aad745d015b2a62ae/pytest-5.4.2-py3-none-any.whl
Collecting jinja2 (from wickedhot==0.1.6)
  Using cached https://files.pythonhosted.org/packages/30/9e/f663a2aa66a09d838042ae1a2c5659828bb9b41ea3a6efa20a20fd92b121/Jinja2-2.11.2-py2.py3-none-any.whl
Collecting wcwidth (from pytest->wickedhot==0.1.6)
  Using cached https://files.pythonhosted.org/packages/f6/d5/1ecdac957e3ea12c1b319fcdee8b6917ffaff8b4644d673c4d72d2f20b49/wcwidth-0.1.9-py2.py3-none-any.whl
Collecting more-itertools>=4.0.0 (from pytest->wickedhot==0.1.6)
  Using cached https://files.pythonhosted.org/packages/06/b1/2dcadc4861c505a807d5c6d88928450fe5afcf352f205432572a10d74657/more_itertools-8.3.0-py3-none-any.whl
Collecting attrs>=17.4.0 (from pytest->wickedhot==0.1.6)
  Using cached https://files.pythonhosted.org/packages/a2/db/4313ab3be961f7a763066401fb77f7748373b6094076ae2bda2806988af6/attrs-19.3.0-py2.py3-none-any.whl
Collecting packaging (from pytest->wickedhot==0.1.6)
  Using cached https://files.pythonhosted.org/packages/46/19/c5ab91b1b05cfe63cccd5cfc971db9214c6dd6ced54e33c30d5af1d2bc43/packaging-20.4-py2.py3-none-any.whl
Collecting pluggy<1.0,>=0.12 (from pytest->wickedhot==0.1.6)
  Using cached https://files.pythonhosted.org/packages/a0/28/85c7aa31b80d150b772fbe4a229487bc6644da9ccb7e427dd8cc60cb8a62/pluggy-0.13.1-py2.py3-none-any.whl
Collecting py>=1.5.0 (from pytest->wickedhot==0.1.6)
  Using cached https://files.pythonhosted.org/packages/99/8d/21e1767c009211a62a8e3067280bfce76e89c9f876180308515942304d2d/py-1.8.1-py2.py3-none-any.whl
Collecting MarkupSafe>=0.23 (from jinja2->wickedhot==0.1.6)
  Using cached https://files.pythonhosted.org/packages/4b/20/f6d7648c81cb84815d0be935d5c74cd1cc0239e43eadb1a61062d34b6543/MarkupSafe-1.1.1-cp38-cp38-manylinux1_x86_64.whl
Collecting pyparsing>=2.0.2 (from packaging->pytest->wickedhot==0.1.6)
  Using cached https://files.pythonhosted.org/packages/8a/bb/488841f56197b13700afd5658fc279a2025a39e22449b7cf29864669b15d/pyparsing-2.4.7-py2.py3-none-any.whl
Collecting six (from packaging->pytest->wickedhot==0.1.6)
  Using cached https://files.pythonhosted.org/packages/ee/ff/48bde5c0f013094d729fe4b0316ba2a24774b3ff1c52d924a8a4cb04078a/six-1.15.0-py2.py3-none-any.whl
Installing collected packages: wcwidth, more-itertools, attrs, pyparsing, six, packaging, pluggy, py, pytest, MarkupSafe, jinja2, wickedhot
  Running setup.py install for wickedhot: started
    Running setup.py install for wickedhot: finished with status 'done'
Successfully installed MarkupSafe-1.1.1 attrs-19.3.0 jinja2-2.11.2 more-itertools-8.3.0 packaging-20.4 pluggy-0.13.1 py-1.8.1 pyparsing-2.4.7 pytest-5.4.2 six-1.15.0 wcwidth-0.1.9 wickedhot-0.1.6
WARNING: You are using pip version 19.2.3, however version 20.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
+ echo Success
Success
++ rm -rf /tmp/tmp.ZXZfJegj5c
```
